### PR TITLE
Use facade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,5 +10,8 @@
         }
     ],
     "minimum-stability": "dev",
-    "require": {}
+    "require": {
+        "php": "^7.1",
+        "illuminate/support": "^6.0|^7.0"
+    }
 }

--- a/src/QueryUrl.php
+++ b/src/QueryUrl.php
@@ -4,6 +4,16 @@ namespace Forrestedw\QueryUrlBuilder;
 
 use Illuminate\Support\Facades\Facade;
 
+/**
+ * @method static QueryUrlBuilder filter(string $filter)
+ * @method static QueryUrlBuilder removeFilter(string $filter)
+ * @method static QueryUrlBuilder hasFilter(string $filter)
+ * @method static QueryUrlBuilder setFilter(string $filter, $value)
+ * @method static QueryUrlBuilder sortBy(string $by)
+ * @method static QueryUrlBuilder removeSort()
+ * @method static QueryUrlBuilder reverseSort()
+ * @method static string build()
+ */
 class QueryUrl extends Facade
 {
     protected static function getFacadeAccessor()

--- a/src/QueryUrl.php
+++ b/src/QueryUrl.php
@@ -1,132 +1,13 @@
 <?php
 
-
 namespace Forrestedw\QueryUrlBuilder;
 
+use Illuminate\Support\Facades\Facade;
 
-class QueryUrl
+class QueryUrl extends Facade
 {
-    /**
-     * The query's filter value(s)
-     * @var array|null
-     */
-    public $filter;
-
-    /**
-     * The attribute to sort by.
-     * @var
-     */
-    public $sort;
-
-    public function __construct()
+    protected static function getFacadeAccessor()
     {
-        $query = request()->query();
-        $this->sort = $query['sort'] ?? null;
-        $this->filter = $query['filter'] ?? null;
-    }
-
-    /**
-     * The value of a filter in the query.
-     *
-     * @param $filter
-     * @return bool
-     */
-    public function filter($filter)
-    {
-        $value = $this->filter[$filter];
-
-        if($value == '1' || $value == '0') {
-            return (boolean)$value;
-        }
-        return $value;
-    }
-
-    /**
-     * Remove a filter from the query.
-     *
-     * @param $filter
-     * @return $this
-     */
-    public function removeFilter($filter)
-    {
-        unset($this->filter[$filter]);
-
-        return $this;
-    }
-
-    /**
-     * Whether a query has a given filter.
-     *
-     * @param string $filter
-     * @return bool
-     */
-    public function hasFilter(string $filter) : bool
-    {
-        if(! $this->filter) {
-            return false;
-        }
-        if(array_key_exists($filter, $this->filter)) {
-            return true;
-        }
-        return false;
-    }
-
-    /**
-     * Set the value of a filter.
-     *
-     * @param $filter
-     * @param $value
-     * @return $this
-     */
-    public function setFilter($filter, $value)
-    {
-        $this->filter[$filter] = $value;
-
-        return $this;
-    }
-
-    /**
-     * The attribute to sort by.
-     *
-     * @param string $by
-     * @return $this
-     */
-    public function sortBy(string $by)
-    {
-        $this->sort = $by;
-
-        return $this;
-    }
-
-    public function removeSort()
-    {
-        $this->sort = null;
-
-        return $this;
-    }
-    /**
-     * Reverse the order of a sort/
-     *
-     * @return $this
-     */
-    public function reserveSort()
-    {
-        if($this->sort[0] === '-') {
-            $this->sort = str_replace('-', '', $this->sort);
-        }
-        $this->sort = '-' . $this->sort;
-
-        return $this;
-    }
-
-    /**
-     *
-     * @return mixed
-     */
-    public function build()
-    {
-        $entities = ['%21', '%2A', '%27', '%28', '%29', '%3B', '%3A', '%40', '%26', '%3D', '%2B', '%24', '%2C', '%2F', '%3F', '%25', '%23', '%5B', '%5D'];
-        $replacements = ['!', '*', "'", "(", ")", ";", ":", "@", "&", "=", "+", "$", ",", "/", "?", "%", "#", "[", "]"];
-        return request()->url() . '/?'. str_replace($entities, $replacements, http_build_query( (array) $this));
+        return 'query-url-builder';
     }
 }

--- a/src/QueryUrlBuilder.php
+++ b/src/QueryUrlBuilder.php
@@ -4,7 +4,7 @@
 namespace Forrestedw\QueryUrlBuilder;
 
 
-class QueryUrlManager
+class QueryUrlBuilder
 {
     /**
      * The query's filter value(s)

--- a/src/QueryUrlBuilderServiceProvider.php
+++ b/src/QueryUrlBuilderServiceProvider.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Forrestedw\QueryUrlBuilder;
+
+use Illuminate\Support\ServiceProvider;
+
+class QueryUrlBuilderServiceProvider extends ServiceProvider
+{
+    /**
+     * Register services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        //
+    }
+
+    /**
+     * Bootstrap services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        //
+    }
+}

--- a/src/QueryUrlBuilderServiceProvider.php
+++ b/src/QueryUrlBuilderServiceProvider.php
@@ -13,7 +13,9 @@ class QueryUrlBuilderServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        //
+        $this->app->singleton('query-url-builder', function ($app) {
+            return new QueryUrlBuilder();
+        });
     }
 
     /**

--- a/src/QueryUrlBuilderServiceProvider.php
+++ b/src/QueryUrlBuilderServiceProvider.php
@@ -13,7 +13,7 @@ class QueryUrlBuilderServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->singleton('query-url-builder', function ($app) {
+        $this->app->bind('query-url-builder', function ($app) {
             return new QueryUrlBuilder();
         });
     }

--- a/src/QueryUrlManager.php
+++ b/src/QueryUrlManager.php
@@ -1,0 +1,132 @@
+<?php
+
+
+namespace Forrestedw\QueryUrlBuilder;
+
+
+class QueryUrlManager
+{
+    /**
+     * The query's filter value(s)
+     * @var array|null
+     */
+    public $filter;
+
+    /**
+     * The attribute to sort by.
+     * @var
+     */
+    public $sort;
+
+    public function __construct()
+    {
+        $query = request()->query();
+        $this->sort = $query['sort'] ?? null;
+        $this->filter = $query['filter'] ?? null;
+    }
+
+    /**
+     * The value of a filter in the query.
+     *
+     * @param $filter
+     * @return bool
+     */
+    public function filter($filter)
+    {
+        $value = $this->filter[$filter];
+
+        if($value == '1' || $value == '0') {
+            return (boolean)$value;
+        }
+        return $value;
+    }
+
+    /**
+     * Remove a filter from the query.
+     *
+     * @param $filter
+     * @return $this
+     */
+    public function removeFilter($filter)
+    {
+        unset($this->filter[$filter]);
+
+        return $this;
+    }
+
+    /**
+     * Whether a query has a given filter.
+     *
+     * @param string $filter
+     * @return bool
+     */
+    public function hasFilter(string $filter) : bool
+    {
+        if(! $this->filter) {
+            return false;
+        }
+        if(array_key_exists($filter, $this->filter)) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Set the value of a filter.
+     *
+     * @param $filter
+     * @param $value
+     * @return $this
+     */
+    public function setFilter($filter, $value)
+    {
+        $this->filter[$filter] = $value;
+
+        return $this;
+    }
+
+    /**
+     * The attribute to sort by.
+     *
+     * @param string $by
+     * @return $this
+     */
+    public function sortBy(string $by)
+    {
+        $this->sort = $by;
+
+        return $this;
+    }
+
+    public function removeSort()
+    {
+        $this->sort = null;
+
+        return $this;
+    }
+    /**
+     * Reverse the order of a sort/
+     *
+     * @return $this
+     */
+    public function reserveSort()
+    {
+        if($this->sort[0] === '-') {
+            $this->sort = str_replace('-', '', $this->sort);
+        }
+        $this->sort = '-' . $this->sort;
+
+        return $this;
+    }
+
+    /**
+     *
+     * @return mixed
+     */
+    public function build()
+    {
+        $entities = ['%21', '%2A', '%27', '%28', '%29', '%3B', '%3A', '%40', '%26', '%3D', '%2B', '%24', '%2C', '%2F', '%3F', '%25', '%23', '%5B', '%5D'];
+        $replacements = ['!', '*', "'", "(", ")", ";", ":", "@", "&", "=", "+", "$", ",", "/", "?", "%", "#", "[", "]"];
+        return request()->url() . '/?'. str_replace($entities, $replacements, http_build_query( (array) $this));
+    }
+}


### PR DESCRIPTION
Laravel discourages the use of too much helper functions so with this PR we aim to remove initializing a global query builder.

So from :
```php
if(! function_exists('queryUrl')) {
    function queryUrl()
    {
        return (new \Forrestedw\QueryUrlBuilder\QueryUrl);
    }
}

queryUrl()->sortBy('name')->build();
```
to something like
```php
use Forrestedw\QueryUrlBuilder\QueryUrl;

/** more code **/
QueryUrl::sortBy('name')->build();
```