### PR TITLE
Added support for named route

### DIFF
--- a/src/QueryUrl.php
+++ b/src/QueryUrl.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Facade;
 
 /**
  * @method static QueryUrlBuilder filter(string $filter)
- * @method static QueryUrlBuilder forUrl(string $url, bool $namedRoute = false)
+ * @method static QueryUrlBuilder forUrl(string $url, bool $namedRoute = false, array $params = [])
  * @method static QueryUrlBuilder removeFilter(string $filter)
  * @method static QueryUrlBuilder hasFilter(string $filter)
  * @method static QueryUrlBuilder setFilter(string $filter, $value)

--- a/src/QueryUrl.php
+++ b/src/QueryUrl.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Facade;
 
 /**
  * @method static QueryUrlBuilder filter(string $filter)
- * @method static QueryUrlBuilder forUrl(string $url)
+ * @method static QueryUrlBuilder forUrl(string $url, bool $namedRoute = false)
  * @method static QueryUrlBuilder removeFilter(string $filter)
  * @method static QueryUrlBuilder hasFilter(string $filter)
  * @method static QueryUrlBuilder setFilter(string $filter, $value)

--- a/src/QueryUrl.php
+++ b/src/QueryUrl.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Facade;
 
 /**
  * @method static QueryUrlBuilder filter(string $filter)
- * @method static QueryUrlBuilder forUrl(string $url, bool $namedRoute = false, array $params = [])
+ * @method static QueryUrlBuilder forUrl(string $urlOrNamedRoute, array $params = [])
  * @method static QueryUrlBuilder removeFilter(string $filter)
  * @method static QueryUrlBuilder hasFilter(string $filter)
  * @method static QueryUrlBuilder setFilter(string $filter, $value)

--- a/src/QueryUrlBuilder.php
+++ b/src/QueryUrlBuilder.php
@@ -81,16 +81,17 @@ class QueryUrlBuilder
      * Sets a custom url to apply filters on.
      *
      * @param string $url
-     * @param bool $namedRoute
+     * @param bool $namedRoute     *
+     * @param array $params
      *
      * @return $this
      */
-    public function forUrl(string $url, bool $namedRoute = false)
+    public function forUrl(string $url, bool $namedRoute = false, array $params = [])
     {
         $this->url = url($url);
 
         if($namedRoute){
-            $this->url = route($url);
+            $this->url = route($url, $params);
         }
 
         return $this;

--- a/src/QueryUrlBuilder.php
+++ b/src/QueryUrlBuilder.php
@@ -82,18 +82,17 @@ class QueryUrlBuilder
     /**
      * Sets a custom url to apply filters on.
      *
-     * @param string $url
-     * @param bool $namedRoute     *
+     * @param string $urlOrNamedRoute
      * @param array $params
      *
      * @return $this
      */
     public function forUrl(string $urlOrNamedRoute, array $params = [])
     {
+        $this->url = url($urlOrNamedRoute);
+
         if(Route::has($urlOrNamedRoute)){
             $this->url = route($urlOrNamedRoute, $params);
-        } else {
-            $this->url = url($urlOrNamedRoute);
         }
 
         return $this;
@@ -201,7 +200,7 @@ class QueryUrlBuilder
         if($this->url){
             unset($queryData['url']);
         }
-        return ($this->url ?? request()->url()) . '/?'. str_replace($entities, $replacements, http_build_query($queryData));
+        return ($this->url ?? request()->url()) . '?'. str_replace($entities, $replacements, http_build_query($queryData));
     }
 
     /**

--- a/src/QueryUrlBuilder.php
+++ b/src/QueryUrlBuilder.php
@@ -4,6 +4,8 @@
 namespace Forrestedw\QueryUrlBuilder;
 
 
+use Illuminate\Support\Facades\Route;
+
 class QueryUrlBuilder
 {
     /**
@@ -86,12 +88,12 @@ class QueryUrlBuilder
      *
      * @return $this
      */
-    public function forUrl(string $url, bool $namedRoute = false, array $params = [])
+    public function forUrl(string $urlOrNamedRoute, array $params = [])
     {
-        $this->url = url($url);
-
-        if($namedRoute){
-            $this->url = route($url, $params);
+        if(Route::has($urlOrNamedRoute)){
+            $this->url = route($urlOrNamedRoute, $params);
+        } else {
+            $this->url = url($urlOrNamedRoute);
         }
 
         return $this;

--- a/src/QueryUrlBuilder.php
+++ b/src/QueryUrlBuilder.php
@@ -81,12 +81,17 @@ class QueryUrlBuilder
      * Sets a custom url to apply filters on.
      *
      * @param string $url
+     * @param bool $namedRoute
      *
      * @return $this
      */
-    public function forUrl(string $url)
+    public function forUrl(string $url, bool $namedRoute = false)
     {
         $this->url = url($url);
+
+        if($namedRoute){
+            $this->url = route($url);
+        }
 
         return $this;
     }


### PR DESCRIPTION
So currently its supporting a plain url now we can add named routes too.
```php
//in web.php
Route::get('test-route', ...)->name('testName');

//we call it like
QueryUrl::forUrl('testName', true)->build();
```
By default the facade uses plain urls

**Named routes with params:**
```php
//for example in route file
Route::get('test/{user}', ...)->name('testRoute');

//call as follows
QueryUrl::forUrl('testRoute', true, [
	'user' => 3
]);
```
